### PR TITLE
Add minBlockLength 64 to all ttl

### DIFF
--- a/2Voices/ttl/2Voices.ttl
+++ b/2Voices/ttl/2Voices.ttl
@@ -11,7 +11,10 @@
 <http://moddevices.com/plugins/mod-devel/2Voices>
 a lv2:Plugin, lv2:SpectralPlugin;
 
-lv2:requiredFeature bsize:fixedBlockLength, bsize:powerOf2BlockLength;
+lv2:requiredFeature bsize:fixedBlockLength, bsize:powerOf2BlockLength,
+       bsize:boundedBlockLength ;
+bsize:minBlockLength 64 ;
+bsize:maxBlockLength 8192 ;
 
 doap:name "2Voices";
 

--- a/Capo/ttl/Capo.ttl
+++ b/Capo/ttl/Capo.ttl
@@ -12,7 +12,10 @@
 <http://moddevices.com/plugins/mod-devel/Capo>
 a lv2:Plugin, lv2:SpectralPlugin;
 
-lv2:requiredFeature bsize:fixedBlockLength, bsize:powerOf2BlockLength;
+lv2:requiredFeature bsize:fixedBlockLength, bsize:powerOf2BlockLength,
+       bsize:boundedBlockLength ;
+bsize:minBlockLength 64 ;
+bsize:maxBlockLength 8192 ;
 
 doap:name "Capo";
 

--- a/Drop/ttl/Drop.ttl
+++ b/Drop/ttl/Drop.ttl
@@ -12,7 +12,10 @@
 <http://moddevices.com/plugins/mod-devel/Drop>
 a lv2:Plugin, lv2:SpectralPlugin;
 
-lv2:requiredFeature bsize:fixedBlockLength, bsize:powerOf2BlockLength;
+lv2:requiredFeature bsize:fixedBlockLength, bsize:powerOf2BlockLength,
+       bsize:boundedBlockLength ;
+bsize:minBlockLength 64 ;
+bsize:maxBlockLength 8192 ;
 
 doap:name "Drop";
 

--- a/Harmonizer/ttl/Harmonizer.ttl
+++ b/Harmonizer/ttl/Harmonizer.ttl
@@ -12,7 +12,10 @@
 <http://moddevices.com/plugins/mod-devel/Harmonizer>
 a lv2:Plugin, lv2:SpectralPlugin;
 
-lv2:requiredFeature bsize:fixedBlockLength, bsize:powerOf2BlockLength;
+lv2:requiredFeature bsize:fixedBlockLength, bsize:powerOf2BlockLength,
+       bsize:boundedBlockLength ;
+bsize:minBlockLength 64 ;
+bsize:maxBlockLength 8192 ;
 
 doap:name "Harmonizer";
 

--- a/Harmonizer2/ttl/Harmonizer2.ttl
+++ b/Harmonizer2/ttl/Harmonizer2.ttl
@@ -12,8 +12,10 @@
 <http://moddevices.com/plugins/mod-devel/Harmonizer2>
 a lv2:Plugin, lv2:SpectralPlugin;
 
-lv2:requiredFeature bsize:fixedBlockLength, bsize:powerOf2BlockLength;
-
+lv2:requiredFeature bsize:fixedBlockLength, bsize:powerOf2BlockLength,
+       bsize:boundedBlockLength ;
+bsize:minBlockLength 64 ;
+bsize:maxBlockLength 8192 ;
 doap:name "Harmonizer2";
 
 doap:developer [

--- a/HarmonizerCS/ttl/HarmonizerCS.ttl
+++ b/HarmonizerCS/ttl/HarmonizerCS.ttl
@@ -12,7 +12,10 @@
 <http://moddevices.com/plugins/mod-devel/HarmonizerCS>
 a lv2:Plugin, lv2:SpectralPlugin;
 
-lv2:requiredFeature bsize:fixedBlockLength, bsize:powerOf2BlockLength;
+lv2:requiredFeature bsize:fixedBlockLength, bsize:powerOf2BlockLength,
+       bsize:boundedBlockLength ;
+bsize:minBlockLength 64 ;
+bsize:maxBlockLength 8192 ;
 
 doap:name "HarmonizerCS";
 

--- a/SuperCapo/ttl/SuperCapo.ttl
+++ b/SuperCapo/ttl/SuperCapo.ttl
@@ -12,7 +12,10 @@
 <http://moddevices.com/plugins/mod-devel/SuperCapo>
 a lv2:Plugin, lv2:SpectralPlugin;
 
-lv2:requiredFeature bsize:fixedBlockLength, bsize:powerOf2BlockLength;
+lv2:requiredFeature bsize:fixedBlockLength, bsize:powerOf2BlockLength,
+       bsize:boundedBlockLength ;
+bsize:minBlockLength 64 ;
+bsize:maxBlockLength 8192 ;
 
 doap:name "Super Capo";
 

--- a/SuperWhammy/ttl/SuperWhammy.ttl
+++ b/SuperWhammy/ttl/SuperWhammy.ttl
@@ -12,7 +12,10 @@
 <http://moddevices.com/plugins/mod-devel/SuperWhammy>
 a lv2:Plugin, lv2:SpectralPlugin;
 
-lv2:requiredFeature bsize:fixedBlockLength, bsize:powerOf2BlockLength;
+lv2:requiredFeature bsize:fixedBlockLength, bsize:powerOf2BlockLength,
+       bsize:boundedBlockLength ;
+bsize:minBlockLength 64 ;
+bsize:maxBlockLength 8192 ;
 
 doap:name "Super Whammy";
 


### PR DESCRIPTION
According to lv2 when using fixedBlockLength, minBlockLength and maxBlockLength must be provided.
https://lv2plug.in/ns/ext/buf-size#fixedBlockLength

since
> These effects are supposed to work well with the following values of Frames/Period: 64, 128, 256, 512
lv2 host must know that to work well.